### PR TITLE
Remove Selenium.Support and update WebDriver script calls

### DIFF
--- a/src/BlazorWebApp/Server/Seedysoft.BlazorWebApp.Server.csproj
+++ b/src/BlazorWebApp/Server/Seedysoft.BlazorWebApp.Server.csproj
@@ -66,8 +66,6 @@
         <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="OneOf" Version="3.0.271" />
         <PackageReference Include="RestSharp" Version="114.0.0" />
-        <PackageReference Include="Selenium.Support" Version="4.43.0" />
-        <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />

--- a/src/WebComparer/ConsoleApp/Seedysoft.WebComparer.ConsoleApp.csproj
+++ b/src/WebComparer/ConsoleApp/Seedysoft.WebComparer.ConsoleApp.csproj
@@ -39,7 +39,6 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
-        <PackageReference Include="Selenium.Support" Version="4.43.0" />
         <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/src/WebComparer/Lib/Seedysoft.WebComparer.Lib.csproj
+++ b/src/WebComparer/Lib/Seedysoft.WebComparer.Lib.csproj
@@ -37,7 +37,6 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
-        <PackageReference Include="Selenium.Support" Version="4.43.0" />
         <PackageReference Include="Selenium.WebDriver" Version="4.43.0" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/src/WebComparer/Lib/Services/WebComparerCronBackgroundService.cs
+++ b/src/WebComparer/Lib/Services/WebComparerCronBackgroundService.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OpenQA.Selenium.Support.Extensions;
 using Seedysoft.Libs.Core.Extensions;
 
 namespace Seedysoft.WebComparer.Lib.Services;
@@ -358,7 +357,7 @@ public sealed class WebComparerCronBackgroundService : Libs.BackgroundServices.C
             {
                 // SubscriptionId: 3 JCyL Convocatorias
                 if (webDriver.PageSource.Contains("elemento-invisible"))
-                    webDriver.ExecuteJavaScript("jQuery('.elemento-invisible').removeClass('elemento-invisible');");
+                    _ = webDriver.ExecuteScript("jQuery('.elemento-invisible').removeClass('elemento-invisible');");
                 // SubscriptionId: 3 JCyL Convocatorias
 
                 // SubscriptionId: 7 Dip Burgos Convocatorias
@@ -369,7 +368,7 @@ public sealed class WebComparerCronBackgroundService : Libs.BackgroundServices.C
                     TextFilterWebElement.Clear();
                     TextFilterWebElement.SendKeys("prog");
                     FormEmpleoFijoWebElement.FindElement(OpenQA.Selenium.By.Id("edit-submit-empleo")).Click();
-                    webDriver.ExecuteJavaScript("jQuery('.collapse').removeClass('collapse');");
+                    _ = webDriver.ExecuteScript("jQuery('.collapse').removeClass('collapse');");
                 }
                 // SubscriptionId: 7 Dip Burgos Convocatorias
 


### PR DESCRIPTION
Removed Selenium.Support package from all projects. Updated WebComparerCronBackgroundService to use ExecuteScript instead of the removed ExecuteJavaScript extension, discarding results explicitly. Cleaned up related using directives. Selenium.WebDriver references remain where required.