### PR TITLE
Update API key, refactor style, and improve test formatting

### DIFF
--- a/src/Libs/GoogleApis/appsettings.GoogleApisSettings.json
+++ b/src/Libs/GoogleApis/appsettings.GoogleApisSettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "https://json.schemastore.org/appsettings.json",
   "GoogleApisSettings": {
-    "ApiKey": "BwIllPBt5jYQNI4cSUS/5RXVIkco/jzejRzw3Zto+Z+dICI2G5hdvtZJXWX5Pgtz/XryRkuWvO6bYkQ5ZRcbog==",
+    "ApiKey": "logq3t3zRGnXDaaIek/4AP9TO/DmR0OgpjK0ME9viOHQ/uMbPeXweymnAyF8230aGOiWAb112Cmaywdq58+jQQ==",
     //"DirectionsApi": {
     //  "BaseUrl": "https://maps.googleapis.com/",
     //  "ResourceUrlFormat": "maps/api/directions/json?&units=metric&alternatives=true&key={0}&origin={1}&destination={2}"

--- a/src/Libs/GoogleMapsRazorClassLib/GoogleMap/Map.razor
+++ b/src/Libs/GoogleMapsRazorClassLib/GoogleMap/Map.razor
@@ -3,7 +3,7 @@
 @inherits SeedysoftComponentBase
 
 <style type="text/css">
-    @($"#{this.Id} {{ height: 100%; }} ")
+    @($"#{Id} {{ height: 100%; }} ")
 </style>
 
 <ScriptsLoader Async

--- a/test/Libs/Cryptography.Tests/CryptoTests.cs
+++ b/test/Libs/Cryptography.Tests/CryptoTests.cs
@@ -4,7 +4,9 @@ public sealed class CryptoTests : Core.Tests.TUnitTestClassBase
 {
     [Test]
     [CombinedDataSources]
-    public void EncryptThenDecryptTest([Arguments("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla tellus, elementum sit amet nunc.")] string textToEncrypt)
+    public void EncryptThenDecryptTest(
+        [Arguments("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla tellus, elementum sit amet nunc.")]
+        string textToEncrypt)
     {
         string Key = System.Security.Cryptography.RandomNumberGenerator.GetString("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", 32);
 


### PR DESCRIPTION
- Updated Google API key in appsettings.GoogleApisSettings.json.
- Refactored Map.razor style to use Id without 'this.'.
- Improved readability of parameter attributes in CryptoTests.cs.